### PR TITLE
Update ServiceTypes.tsx

### DIFF
--- a/src/components/Api/ApiSections/Resources/ServiceTypes.tsx
+++ b/src/components/Api/ApiSections/Resources/ServiceTypes.tsx
@@ -441,7 +441,7 @@ export const ServiceTypes: FC<SectionProps> = ({
                 height={"20"}
                 width={"20"}
               />
-              MAIL_PRIVATE (1 MB)
+              MAIL_PRIVATE (5 MB)
             </CustomListItem>
             <CustomListItem>
               <QortalIcon


### PR DESCRIPTION
Max file size for MAIL_PRIVATE was updated from 1MB to 5MB in the following commit:
https://github.com/Qortal/qortal/commit/21257065fffd5a4e5a22a37dcccab0cfcae7b042